### PR TITLE
Update Docker Images of vala-lint

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   build:
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
     - name: Publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,5 +17,5 @@ jobs:
     - name: Publish
       run: |
         docker login -u ${{ secrets.DockerUsername }} -p ${{ secrets.DockerPassword }}
-        docker build -t elementary/docker:vala-lint .
-        docker push elementary/docker:vala-lint
+        docker build -t valalang/lint:latest .
+        docker push valalang/lint:latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,11 +7,6 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-
-    container:
-      image: elementary/docker:unstable
-
     steps:
     - uses: actions/checkout@v1
     - name: Publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,21 @@
+name: Publish Docker Image
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    container:
+      image: elementary/docker:unstable
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Publish
+      run: |
+        docker login -u ${{ secrets.DockerUsername }} -p ${{ secrets.DockerPassword }}
+        docker build -t elementary/docker:vala-lint .
+        docker push elementary/docker:vala-lint

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,20 +2,32 @@
 
 FROM debian:stable-slim
 
-LABEL Blake Kostner <blake@elementary.io>
+ENV DEBIAN_FRONTEND=noninteractive
 
-COPY . /var/opt/vala-lint
+RUN mkdir -p /opt/vala-lint-portable
 
-WORKDIR /var/opt/vala-lint
+COPY . /opt/vala-lint
+
+RUN apt update \
+  && apt install -y libvala-dev valac meson
+
+RUN cd /opt/vala-lint \
+  && meson build --prefix=/usr \
+  && cd build \
+  && ninja \
+  && DESTDIR=/opt/vala-lint-portable ninja install
+
+FROM debian:stable-slim
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get install -y libvala-dev valac meson
+COPY --from=0 /opt/vala-lint-portable /
 
-RUN meson build --prefix=/usr && cd build && ninja && ninja install
+RUN apt update \
+  && apt install -y libvala-dev gio-2.0
 
-RUN mkdir -p /var/opt/vala-lint
-
-VOLUME /var/opt/vala-lint
+RUN mkdir -p /app
+VOLUME /app
+WORKDIR /app
 
 CMD ["/usr/bin/io.elementary.vala-lint", "**/*.vala"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # elementary docker image for vala-lint
 
-FROM elementary/docker:juno-unstable
+FROM debian:stable-slim
 
 LABEL Blake Kostner <blake@elementary.io>
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# elementary docker image for vala-lint
+
+FROM elementary/docker:juno-unstable
+
+LABEL Blake Kostner <blake@elementary.io>
+
+COPY . /var/opt/vala-lint
+
+WORKDIR /var/opt/vala-lint
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y libvala-dev valac meson
+
+RUN meson build --prefix=/usr && cd build && ninja && ninja install
+
+RUN mkdir -p /var/opt/vala-lint
+
+VOLUME /var/opt/vala-lint
+
+CMD ["/usr/bin/io.elementary.vala-lint", "**/*.vala"]

--- a/README.md
+++ b/README.md
@@ -45,4 +45,4 @@ if(...) { // vala-lint=space-before-paren, line-length
 ### Docker and Continuous Integration
 Vala-Lint is primarily intended to be used in Continuous Integration (CI). It's available in a convenient, always up-to-date Docker container `elementary/docker:vala-lint` hosted on Docker Hub.
 
-    docker run -v "$PWD":/var/opt/vala-lint elementary/docker:vala-lint
+    docker run -v "$PWD":/app elementary/docker:vala-lint

--- a/README.md
+++ b/README.md
@@ -45,4 +45,4 @@ if(...) { // vala-lint=space-before-paren, line-length
 ### Docker and Continuous Integration
 Vala-Lint is primarily intended to be used in Continuous Integration (CI). It's available in a convenient, always up-to-date Docker container `elementary/docker:vala-lint` hosted on Docker Hub.
 
-    docker run -v "$PWD":/app elementary/docker:vala-lint
+    docker run -v "$PWD":/app valalang/lint:latest


### PR DESCRIPTION
This pr should set everything up to enable the vala-lint image to be auto-updated every time there's a push/merge to master. This should hopefully satisfy #96!

**_Note:_** This requires an administrator of the vala-lint project to set up the docker login secrets. After doing so, any merge to master will automatically kick off a new github workflow that will build and publish an updated image.