### PR TITLE
Quote login variables to prevent word splitting

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,6 @@ jobs:
     - uses: actions/checkout@v1
     - name: Publish
       run: |
-        docker login -u ${{ secrets.DockerUsername }} -p ${{ secrets.DockerPassword }}
+        docker login -u "${{ secrets.DockerUsername }}" -p "${{ secrets.DockerPassword }}"
         docker build -t valalang/lint:latest .
         docker push valalang/lint:latest


### PR DESCRIPTION
Last pipeline run failed with an EOF error. From the looks of it, it seems that the username or password may be getting split. This quotes the variables to avoid any word splitting.
