### PR TITLE
Line-length Ignore Comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ disable-by-inline-comments=true
 
 [line-length]
 max-line-length=120
+ignore-comments=true
 
 [note]
 keywords=TODO,FIXME

--- a/lib/Checks/LineLengthCheck.vala
+++ b/lib/Checks/LineLengthCheck.vala
@@ -21,6 +21,7 @@ public class ValaLint.Checks.LineLengthCheck : Check {
     const string MESSAGE = "Line exceeds limit of %d characters (currently %d characters)";
 
     public int maximum_characters { get; set; }
+    public bool ignore_comments { get; set; }
 
     public LineLengthCheck () {
         Object (
@@ -30,26 +31,42 @@ public class ValaLint.Checks.LineLengthCheck : Check {
 
         state = Config.get_state (title);
         maximum_characters = Config.get_integer (title, "max-line-length");
+        ignore_comments = Config.get_boolean (title, "ignore-comments");
+    }
+
+    public void check_line (string line, int line_count, ref Vala.ArrayList<FormatMistake?> mistake_list) {
+        int line_length = line.char_count ();
+        if (line_length > maximum_characters) {
+            string formatted_message = MESSAGE.printf (maximum_characters, line_length);
+
+            var pos = (char *)line;
+            var begin = Vala.SourceLocation (pos + maximum_characters, line_count, maximum_characters);
+            var end = Vala.SourceLocation (pos + line_length, line_count, line_length);
+            add_mistake ({ this, begin, end, formatted_message }, ref mistake_list);
+        }
     }
 
     public override void check (Vala.ArrayList<ParseResult?> parse_result,
                                 ref Vala.ArrayList<FormatMistake?> mistake_list) {
-        string input = "";
+        string line = "";
         foreach (ParseResult r in parse_result) {
-            input += r.text;
-        }
-
-        int line_counter = 1;
-        foreach (string line in input.split ("\n")) {
-            if (line.char_count () > maximum_characters) {
-                int line_length = line.char_count ();
-                string formatted_message = MESSAGE.printf (maximum_characters, line_length);
-
-                var begin = Vala.SourceLocation ((char *)line + maximum_characters, line_counter, maximum_characters);
-                var end = Vala.SourceLocation ((char *)line + line_length, line_counter, line_length);
-                add_mistake ({ this, begin, end, formatted_message }, ref mistake_list);
+            if (r.type == ParseType.COMMENT && ignore_comments) {
+                continue;
             }
-            line_counter += 1;
+
+            var text_split = r.text.split ("\n");
+            for (int i = 0; i < text_split.length - 1; i++) {
+                line += text_split[i];
+
+                check_line (line, r.begin.line + i, ref mistake_list);
+
+                line = "";
+            }
+
+            line += text_split[text_split.length - 1];
         }
+
+        var r = parse_result.last ();
+        check_line (line, r.begin.line, ref mistake_list);
     }
 }

--- a/lib/Checks/LineLengthCheck.vala
+++ b/lib/Checks/LineLengthCheck.vala
@@ -50,20 +50,20 @@ public class ValaLint.Checks.LineLengthCheck : Check {
                                 ref Vala.ArrayList<FormatMistake?> mistake_list) {
         string line = "";
         foreach (ParseResult r in parse_result) {
-            if (r.type == ParseType.COMMENT && ignore_comments) {
-                continue;
-            }
-
             var text_split = r.text.split ("\n");
             for (int i = 0; i < text_split.length - 1; i++) {
-                line += text_split[i];
+                if (r.type != ParseType.COMMENT || !ignore_comments) {
+                    line += text_split[i];
+                }
 
                 check_line (line, r.begin.line + i, ref mistake_list);
 
                 line = "";
             }
 
-            line += text_split[text_split.length - 1];
+            if (r.type != ParseType.COMMENT || !ignore_comments) {
+                line += text_split[text_split.length - 1];
+            }
         }
 
         var r = parse_result.last ();

--- a/lib/Config.vala
+++ b/lib/Config.vala
@@ -48,6 +48,7 @@ public class ValaLint.Config {
         default_config.set_boolean ("Disabler", "disable-by-inline-comments", true);
 
         default_config.set_double ("line-length", "max-line-length", 120);
+        default_config.set_boolean ("line-length", "ignore-comments", true);
 
         default_config.set_string_list ("note", "keywords", {"TODO", "FIXME"});
 

--- a/test/FileTest.vala
+++ b/test/FileTest.vala
@@ -66,6 +66,8 @@ class FileTest : GLib.Object {
         m_warnings.add ({ "ellipsis", line += 0 });
         m_warnings.add ({ "unnecessary-string-template", line += 2 });
         m_warnings.add ({ "unnecessary-string-template", line += 1 });
+        m_warnings.add ({ "line-length", line += 2 });
+        m_warnings.add ({ "line-length", line += 1 });
         m_warnings.add ({ "trailing-newlines", line += 2 });
 
         check_file_for_mistake (File.new_for_path ("../test/files/warnings.vala"), m_warnings);

--- a/test/UnitTest.vala
+++ b/test/UnitTest.vala
@@ -52,7 +52,7 @@ class UnitTest : GLib.Object {
         assert_pass (line_length_check, "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore aliqua."); // vala-lint=line-length
         // This is 70 characters but 140 bytes, it should still pass.
         assert_pass (line_length_check, "éééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééé");
-        assert_warning (line_length_check, "/* Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore aliqua consectetur */ aliqua.", 120, 132); // vala-lint=line-length
+        assert_pass (line_length_check, "/* Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore aliqua consectetur */ aliqua."); // vala-lint=line-length
         assert_warning (line_length_check, "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.", 120, 123); // vala-lint=line-length
 
         var naming_all_caps_check = new ValaLint.Checks.NamingAllCapsCheck ();

--- a/test/files/pass.vala
+++ b/test/files/pass.vala
@@ -1,7 +1,9 @@
 class FileTest : GLib.Object {
 
     public static int main (string[] args) {
-        string no_ellipsis = ".. lorem ipsum.";
+        string no_ellipsis = ".. lorem ipsum."; // This is a very long comment over the line-length limit of 120 characters...
+        string this_is_a_very_long_but_just_under_line_length_variable = "I am staying just under the line length l";
+        string this_is_a_very_long_but_just_under_line_length_comment = /* comments are ignored */ "I am staying just under the line length l";
 
         string literal = "Lorem ipsum";
         var string_template = @"$literal et al.";

--- a/test/files/warnings.vala
+++ b/test/files/warnings.vala
@@ -18,5 +18,8 @@ class FileTest : GLib.Object {
 
         var empty_string_template = @"";
         var content_string_template = @"Lorem ipsum";
+
+        string this_is_a_very_long_variable_name_to_get_over_the_120_character_line_length_limit = "lorem ipsum dolor amet test"; // despite the comment
+        string this_is_a_very_long_variable_name_to_get_over_the_120_character_line_with_comment /* with comment */ = "lorem ipsum dolor amet test"; // and comment here
     }
 }


### PR DESCRIPTION
Adds an option (enabled by default) to ignore comments in line length check. I've added a few more tests to make sure that it works despite the logic changes. Fix #109.