### PR TITLE
NamingConvention: fix name is null error

### DIFF
--- a/lib/Checks/NamingConventionCheck.vala
+++ b/lib/Checks/NamingConventionCheck.vala
@@ -43,7 +43,7 @@ public class ValaLint.Checks.NamingConventionCheck : Check {
     }
 
     public void check_all_caps (Vala.Symbol symbol, ref Vala.ArrayList<FormatMistake?> mistake_list) {
-        if (state == Config.State.OFF) {
+        if (state == Config.State.OFF || symbol.name == null) {
             return;
         }
 
@@ -55,7 +55,7 @@ public class ValaLint.Checks.NamingConventionCheck : Check {
     }
 
     public void check_camel_case (Vala.Symbol symbol, ref Vala.ArrayList<FormatMistake?> mistake_list) {
-        if (state == Config.State.OFF) {
+        if (state == Config.State.OFF || symbol.name == null) {
             return;
         }
 
@@ -67,7 +67,7 @@ public class ValaLint.Checks.NamingConventionCheck : Check {
     }
 
     public void check_underscore (Vala.Symbol symbol, ref Vala.ArrayList<FormatMistake?> mistake_list) {
-        if (state == Config.State.OFF) {
+        if (state == Config.State.OFF || symbol.name == null) {
             return;
         }
 

--- a/test/UnitTest.vala
+++ b/test/UnitTest.vala
@@ -94,7 +94,7 @@ class UnitTest : GLib.Object {
         );
         Assertion<Vala.Method>.pass (
             naming_convention_check.check_camel_case,
-            new Vala.Method (null, new Vala.VoidType())
+            new Vala.Method (null, new Vala.VoidType ())
         );
         Assertion<Vala.Class>.pass (
             naming_convention_check.check_camel_case,

--- a/test/UnitTest.vala
+++ b/test/UnitTest.vala
@@ -92,6 +92,10 @@ class UnitTest : GLib.Object {
             naming_convention_check.check_camel_case,
             new Vala.Class ("LoremIpsum")
         );
+        Assertion<Vala.Method>.pass (
+            naming_convention_check.check_camel_case,
+            new Vala.Method (null, new Vala.VoidType())
+        );
         Assertion<Vala.Class>.pass (
             naming_convention_check.check_camel_case,
             new Vala.Class ("LoremIpsumÄ12")


### PR DESCRIPTION
Checks if the name of a symbol is null.