### PR TITLE
Improve Double Spaces Check

### DIFF
--- a/lib/Checks/BlockOpeningBraceSpaceBeforeCheck.vala
+++ b/lib/Checks/BlockOpeningBraceSpaceBeforeCheck.vala
@@ -38,9 +38,6 @@ public class ValaLint.Checks.BlockOpeningBraceSpaceBeforeCheck : Check {
                                    ref mistake_list, 1, 1);
                 add_regex_mistake ("""[\w)=]{""", _("Expected whitespace before \"{\""), r,
                                    ref mistake_list, 1, 1);
-                // Check for a tab character or more than one whitespace character before the open parenthesis
-                add_regex_mistake ("""[\w)=](?:\t|\s{2,}){""", _("Expected single space before \"{\""), r,
-                                   ref mistake_list, 1, 1);
             }
         }
     }

--- a/lib/Checks/DoubleSpacesCheck.vala
+++ b/lib/Checks/DoubleSpacesCheck.vala
@@ -34,6 +34,7 @@ public class ValaLint.Checks.DoubleSpacesCheck : Check {
             if (r.type == ParseType.DEFAULT) {
                 bool next_is_comment = (i + 1 < parse_result.size && parse_result[i + 1].type == ParseType.COMMENT);
 
+                /* Iterate through lines of parsed result */
                 var text_split = r.text.split ("\n");
                 for (int j = 0; j < text_split.length; j++) {
                     unowned string line_string = text_split[j];
@@ -42,6 +43,7 @@ public class ValaLint.Checks.DoubleSpacesCheck : Check {
                         continue;
                     }
 
+                    /* Trim line_string from whitespaces */
                     int trim_start = 0;
                     int trim_end = line_string.length;
                     if (j > 0 || r.begin.column == 1) {
@@ -55,6 +57,7 @@ public class ValaLint.Checks.DoubleSpacesCheck : Check {
                         }
                     }
 
+                    /* Check remaing substring for multiple double whitespaces */
                     int index = line_string[0:trim_end].index_of ("  ", trim_start);
                     while (index > -1) {
                         int line = r.begin.line + j;

--- a/lib/Checks/DoubleSpacesCheck.vala
+++ b/lib/Checks/DoubleSpacesCheck.vala
@@ -61,7 +61,7 @@ public class ValaLint.Checks.DoubleSpacesCheck : Check {
                     int index = line_string[0:trim_end].index_of ("  ", trim_start);
                     while (index > -1) {
                         int line = r.begin.line + j;
-                        int column = (j == 0) ? r.begin.column + index : index;
+                        int column = (j == 0) ? r.begin.column + index : index + 1;
 
                         var begin = Vala.SourceLocation ((char *)line_string + index, line, column);
                         var end = Utils.shift_location (begin, 2);

--- a/lib/Checks/DoubleSpacesCheck.vala
+++ b/lib/Checks/DoubleSpacesCheck.vala
@@ -64,7 +64,7 @@ public class ValaLint.Checks.DoubleSpacesCheck : Check {
                         }
                         var begin = Vala.SourceLocation (index, r.begin.line + j, column);
                         var end = Utils.shift_location (begin, 2);
-                        add_mistake ({ this, begin, end, "Expected single space" }, ref mistake_list);
+                        add_mistake ({ this, begin, end, "Expected a single space" }, ref mistake_list);
 
                         while (index[0].isspace () && index < pos_end) {
                             index += 1;

--- a/lib/Checks/DoubleSpacesCheck.vala
+++ b/lib/Checks/DoubleSpacesCheck.vala
@@ -43,35 +43,34 @@ public class ValaLint.Checks.DoubleSpacesCheck : Check {
                         continue;
                     }
 
-                    /* Trim line_string from whitespaces */
-                    int trim_start = 0;
-                    int trim_end = line_string.length;
+                    char* pos_start = (char *)line_string;
+                    char* pos_end = pos_start + line_string.length;
                     if (j > 0 || r.begin.column == 1) {
-                        while (line_string[trim_start].isspace () && trim_start < trim_end) {
-                            trim_start += 1;
+                        while (pos_start[0].isspace () && pos_start < pos_end) {
+                            pos_start += 1;
                         }
                     }
                     if (j < text_split.length - 1 || next_is_comment) {
-                        while (line_string[trim_end - 1].isspace () && trim_end > trim_start) {
-                            trim_end -= 1;
+                        while (pos_end[-1].isspace () && pos_end > pos_start) {
+                            pos_end -= 1;
                         }
                     }
 
-                    /* Check remaing substring for multiple double whitespaces */
-                    int index = line_string[0:trim_end].index_of ("  ", trim_start);
-                    while (index > -1) {
-                        int line = r.begin.line + j;
-                        int column = (j == 0) ? r.begin.column + index : index + 1;
-
-                        var begin = Vala.SourceLocation ((char *)line_string + index, line, column);
+                    char* index = Utils.get_pos_of ("  ", pos_start, pos_end);
+                    while (index != null) {
+                        int column = Utils.get_column_of ((char *)line_string, index);
+                        if (j == 0) {
+                            column += r.begin.column - 1;
+                        }
+                        var begin = Vala.SourceLocation (index, r.begin.line + j, column);
                         var end = Utils.shift_location (begin, 2);
                         add_mistake ({ this, begin, end, "Expected single space" }, ref mistake_list);
 
-                        while (line_string[index].isspace () && index < trim_end) {
+                        while (index[0].isspace () && index < pos_end) {
                             index += 1;
                         }
 
-                        index = line_string[0:trim_end].index_of ("  ", index + 1);
+                        index = Utils.get_pos_of ("  ", index + 1, pos_end);
                     }
                 }
 

--- a/lib/Utils.vala
+++ b/lib/Utils.vala
@@ -18,6 +18,33 @@
  */
 
 public class ValaLint.Utils : Object {
+
+    /**
+     * Method to get the position within an input string. Similar to index_of, but for non-null terminated strings using char pointers.
+     *
+     * @return The position of first index, otherwise null.
+     */
+    public static char* get_pos_of (string needle, char* begin, char* end) {
+        char* pos = begin;
+        while (pos <= end - needle.length) {
+            bool equal = true;
+            for (int i = 0; i < needle.length; i++) {
+                if (pos[i] != needle[i]) {
+                    equal = false;
+                    break;
+                }
+            }
+
+            if (equal) {
+                return pos;
+            }
+
+            pos += 1;
+        }
+
+        return null;
+    }
+
     /**
      * Method to get the line count of a string.
      *
@@ -34,6 +61,19 @@ public class ValaLint.Utils : Object {
      */
     public static int get_column_in_line (string input, int pos) {
         return pos - input[0:pos].last_index_of_char ('\n') - 1;
+    }
+
+    /**
+     * Method to get the char position in the current line of the input string using char pointers.
+     *
+     * @return The char column.
+     */
+    public static int get_column_of (char* begin, char* pos) {
+        int i = 0;
+        while ((pos - i)[-1] != '\n' && pos - i > begin) {
+            i += 1;
+        }
+        return i + 1;
     }
 
     /**

--- a/test/FileTest.vala
+++ b/test/FileTest.vala
@@ -63,6 +63,7 @@ class FileTest : GLib.Object {
         m_warnings.add ({ "double-spaces", line += 1 });
         m_warnings.add ({ "double-spaces", line += 0 });
         m_warnings.add ({ "double-spaces", line += 0 });
+        m_warnings.add ({ "double-spaces", line += 1 });
         m_warnings.add ({ "trailing-whitespace", line += 1 });
         m_warnings.add ({ "no-space", line += 3 });
         m_warnings.add ({ "double-semicolon", line += 1 });

--- a/test/FileTest.vala
+++ b/test/FileTest.vala
@@ -60,6 +60,9 @@ class FileTest : GLib.Object {
         m_warnings.add ({ "note", line += 1, "TODO" });
         m_warnings.add ({ "note", line += 1, "TODO: Lorem ipsum" });
         m_warnings.add ({ "double-spaces", line += 2 });
+        m_warnings.add ({ "double-spaces", line += 1 });
+        m_warnings.add ({ "double-spaces", line += 0 });
+        m_warnings.add ({ "double-spaces", line += 0 });
         m_warnings.add ({ "trailing-whitespace", line += 1 });
         m_warnings.add ({ "no-space", line += 3 });
         m_warnings.add ({ "double-semicolon", line += 1 });

--- a/test/FileTest.vala
+++ b/test/FileTest.vala
@@ -59,7 +59,9 @@ class FileTest : GLib.Object {
         m_warnings.add ({ "space-before-paren", line += 2 });
         m_warnings.add ({ "note", line += 1, "TODO" });
         m_warnings.add ({ "note", line += 1, "TODO: Lorem ipsum" });
-        m_warnings.add ({ "no-space", line += 5 });
+        m_warnings.add ({ "double-spaces", line += 2 });
+        m_warnings.add ({ "trailing-whitespace", line += 1 });
+        m_warnings.add ({ "no-space", line += 3 });
         m_warnings.add ({ "double-semicolon", line += 1 });
         m_warnings.add ({ "naming-convention", line += 1 });
         m_warnings.add ({ "ellipsis", line += 2 });

--- a/test/UnitTest.vala
+++ b/test/UnitTest.vala
@@ -24,7 +24,6 @@ class UnitTest : GLib.Object {
         assert_pass (block_parenthesis_check, "test () {");
         assert_warning (block_parenthesis_check, "test (){", 8, 9);
         assert_warning (block_parenthesis_check, "test ()\n{", 8, 0); // Mistake end in new line
-        assert_warning (block_parenthesis_check, "test ()   {", 8, 9);
 
         var double_spaces_check = new ValaLint.Checks.DoubleSpacesCheck ();
         assert_pass (double_spaces_check, "/*    *//*");

--- a/test/files/pass.vala
+++ b/test/files/pass.vala
@@ -8,6 +8,8 @@ class FileTest : GLib.Object {
         string literal = "Lorem ipsum";
         var string_template = @"$literal et al.";
 
+        var /* comment */ string_double_space = /* */ "lorem";
+
         return 0;
     }
 }

--- a/test/files/warnings.vala
+++ b/test/files/warnings.vala
@@ -8,7 +8,8 @@ class FileTest : GLib.Object {
         test (); // TODO: Lorem ipsum
 
         int double_space  = 2;
-        string  double_space_string  =  "";
+        string  double_space_string  =  _("");
+        test  ();
         return 0;  
     }
 

--- a/test/files/warnings.vala
+++ b/test/files/warnings.vala
@@ -7,7 +7,8 @@ class FileTest : GLib.Object {
         test (); // TODO
         test (); // TODO: Lorem ipsum
 
-        return 0;
+        int double_space  = 2;
+        return 0;  
     }
 
     public void test (string a,string b) {

--- a/test/files/warnings.vala
+++ b/test/files/warnings.vala
@@ -8,6 +8,7 @@ class FileTest : GLib.Object {
         test (); // TODO: Lorem ipsum
 
         int double_space  = 2;
+        string  double_space_string  =  "";
         return 0;  
     }
 


### PR DESCRIPTION
This PR removes the double space check for trailing whitespaces (Fix #92). Additionally, it removes the double spaces check from the `BlockOpeningBraceSpaceBeforeCheck` so that duplicated mistakes should be avoided.