### PR TITLE
Add Exceptions to Name Convention Check

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ disable-by-inline-comments=true
 max-line-length=120
 ignore-comments=true
 
+[naming-convention]
+exceptions=UUID
+
 [note]
 keywords=TODO,FIXME
 ```

--- a/lib/Checks/NamingConventionCheck.vala
+++ b/lib/Checks/NamingConventionCheck.vala
@@ -18,6 +18,8 @@
  */
 
 public class ValaLint.Checks.NamingConventionCheck : Check {
+    public string[] exceptions { get; set; }
+
     public NamingConventionCheck () {
         Object (
             title: _("naming-convention"),
@@ -25,6 +27,7 @@ public class ValaLint.Checks.NamingConventionCheck : Check {
         );
 
         state = Config.get_state (title);
+        exceptions = Config.get_string_list (title, "exceptions");
     }
 
     public override void check (Vala.ArrayList<ParseResult?> parse_result,
@@ -32,7 +35,7 @@ public class ValaLint.Checks.NamingConventionCheck : Check {
 
     }
 
-    private bool name_is_invalid (string name) {
+    private bool name_has_invalid_char (string name) {
         unichar c;
         for (int i = 0; name.get_next_char (ref i, out c);) {
             if (!(c.isalpha () || c.isdigit () || c == '_')) {
@@ -43,11 +46,11 @@ public class ValaLint.Checks.NamingConventionCheck : Check {
     }
 
     public void check_all_caps (Vala.Symbol symbol, ref Vala.ArrayList<FormatMistake?> mistake_list) {
-        if (state == Config.State.OFF || symbol.name == null) {
+        if (state == Config.State.OFF || symbol.name == null || symbol.name in exceptions) {
             return;
         }
 
-        if (symbol.name != symbol.name.up () || name_is_invalid (symbol.name)) {
+        if (symbol.name != symbol.name.up () || name_has_invalid_char (symbol.name)) {
             var begin = symbol.source_reference.begin;
             var end = Utils.shift_location (begin, symbol.name.length);
             add_mistake ({ this, begin, end, _("Expected variable name in ALL_CAPS_CONVENTION") }, ref mistake_list);
@@ -55,11 +58,11 @@ public class ValaLint.Checks.NamingConventionCheck : Check {
     }
 
     public void check_camel_case (Vala.Symbol symbol, ref Vala.ArrayList<FormatMistake?> mistake_list) {
-        if (state == Config.State.OFF || symbol.name == null) {
+        if (state == Config.State.OFF || symbol.name == null || symbol.name in exceptions) {
             return;
         }
 
-        if (symbol.name[0].islower () || symbol.name.contains ("_") || name_is_invalid (symbol.name)) {
+        if (symbol.name[0].islower () || symbol.name.contains ("_") || name_has_invalid_char (symbol.name)) {
             var begin = symbol.source_reference.begin;
             var end = Utils.shift_location (begin, symbol.name.length);
             add_mistake ({ this, begin, end, _("Expected variable name in CamelCaseConvention") }, ref mistake_list);
@@ -67,11 +70,11 @@ public class ValaLint.Checks.NamingConventionCheck : Check {
     }
 
     public void check_underscore (Vala.Symbol symbol, ref Vala.ArrayList<FormatMistake?> mistake_list) {
-        if (state == Config.State.OFF || symbol.name == null) {
+        if (state == Config.State.OFF || symbol.name == null || symbol.name in exceptions) {
             return;
         }
 
-        if (symbol.name != symbol.name.down () || name_is_invalid (symbol.name)) {
+        if (symbol.name != symbol.name.down () || name_has_invalid_char (symbol.name)) {
             var begin = symbol.source_reference.begin;
             var end = Utils.shift_location (begin, symbol.name.length);
             add_mistake ({ this, begin, end, _("Expected variable name in underscore_convention") }, ref mistake_list);

--- a/lib/Config.vala
+++ b/lib/Config.vala
@@ -63,6 +63,8 @@ public class ValaLint.Config {
         default_config.set_double ("line-length", "max-line-length", 120);
         default_config.set_boolean ("line-length", "ignore-comments", true);
 
+        default_config.set_string_list ("naming-convention", "exceptions", {"UUID"});
+
         default_config.set_string_list ("note", "keywords", {"TODO", "FIXME"});
 
         return default_config;

--- a/test/UnitTest.vala
+++ b/test/UnitTest.vala
@@ -128,6 +128,10 @@ class UnitTest : GLib.Object {
             naming_convention_check.check_underscore,
             new Vala.Class ("lorem_ipsum")
         );
+        Assertion<Vala.Class>.pass (
+            naming_convention_check.check_underscore,
+            new Vala.Class ("UUID")
+        );
         Assertion<Vala.Class>.warning (
             naming_convention_check.check_underscore,
             new Vala.Class ("Lorem"), 1, 0, 5

--- a/vala-lint.conf
+++ b/vala-lint.conf
@@ -19,5 +19,8 @@ disable-by-inline-comments=true
 [line-length]
 max-line-length=120
 
+[naming-convention]
+exceptions=UUID
+
 [note]
 keywords=TODO,FIXME


### PR DESCRIPTION
I've added `UUID` as a default name, but the list of exceptions can be set in the config file. Fix #118.