### PR TITLE
Change to Default Arguments in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,4 @@ RUN mkdir -p /app
 VOLUME /app
 WORKDIR /app
 
-CMD ["/usr/bin/io.elementary.vala-lint", "**/*.vala"]
+CMD ["/usr/bin/io.elementary.vala-lint"]


### PR DESCRIPTION
Should fix #121 by using the directory option instead of globs.