### PR TITLE
lib: fix vapi and header names

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -4,11 +4,11 @@ conf.set('prefix', get_option ('prefix'))
 conf.set('libdir', '${exec_prefix}/'+get_option ('libdir'))
 conf.set('PROJECT_NAME', meson.project_name())
 conf.set('VERSION', meson.project_version())
-conf.set('LIBVALA', 'libvala-@0@'.format(libvala_version)+libvala_required_version)
+conf.set('LIBVALA', 'libvala-@0@ '.format(libvala_version)+libvala_required_version)
 
 
-vala_linter_pc = configure_file(input : 'vala-linter-1.0.pc.in',
-	output : 'vala-linter-1.0.pc',
+vala_linter_pc = configure_file(input : 'vala-linter-1.pc.in',
+	output : 'vala-linter-1.pc',
 	configuration : conf
 	)
 install_data(vala_linter_pc,

--- a/data/vala-linter-1.pc.in
+++ b/data/vala-linter-1.pc.in
@@ -8,6 +8,6 @@ Name: vala-linter-1.0
 Description: Library prividing a Vala code files checker for code-style errors
 URL: https://github.com/vala-lang/vala-lint
 Version: @VERSION@
-Requires: gio-2.0>=2.56.4 @LIBVALA@ >= 0.40.4
+Requires: gio-2.0 >= 2.56.4 @LIBVALA@
 Libs: -L${libdir} -lvala-linter-1.0
 Cflags: -I${includedir}/vala-linter-1.0

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -48,8 +48,8 @@ vala_linter_library = shared_library(
     vala_linter_files,
     version : LT_VERSION,
 	soversion : LT_VERSION+'.'+LT_AGE+'.'+LT_REVISION,
-	vala_header : 'vala-lint.h',
-	vala_vapi : 'vala-lint-1.0.vapi',
+	vala_header : 'vala-linter.h',
+	vala_vapi : 'vala-linter-1.vapi',
     dependencies : vala_linter_deps,
     install : true,
 	install_dir : [

--- a/meson.build
+++ b/meson.build
@@ -11,7 +11,7 @@ libvala_version = run_command(valac.cmd_array()[0], '--api-version').stdout().st
 
 gio_dep = dependency('gio-2.0', version: '>=2.56.4')
 posix_dep = valac.find_library('posix')
-libvala_required_version = '>=0.40.0'
+libvala_required_version = '>= 0.40.4'
 libvala_dep = dependency('libvala-@0@'.format(libvala_version), version: libvala_required_version)
 
 subdir('lib')


### PR DESCRIPTION
a library .pc file should use the same name
as the .vapi name, in order to help valac
to find it

This PR helps on fixing the pc file to be used when installed in the system, also the package has been renamed to use today conventions from `vala-linter-1.0` to `vala-linter-1`