### PR TITLE
Minimize docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,9 @@ RUN mkdir -p /opt/vala-lint-portable
 
 COPY . /opt/vala-lint
 
-RUN apt update \
-  && apt install -y libvala-dev valac meson
-
-RUN cd /opt/vala-lint \
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends gcc libvala-dev valac meson\
+  && cd /opt/vala-lint \
   && meson build --prefix=/usr \
   && cd build \
   && ninja \
@@ -23,10 +22,12 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 COPY --from=0 /opt/vala-lint-portable /
 
-RUN apt update \
-  && apt install -y libvala-dev gio-2.0
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends libvala-dev gio-2.0 \
+  && mkdir -p /app \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
 
-RUN mkdir -p /app
 VOLUME /app
 WORKDIR /app
 


### PR DESCRIPTION
__CHANGES:__

Minimize the final docker image size by using `--no-install-recommends` and via cleaning up files leftover from apt-get. By doing so, we can shrink the image size from ~260MB to ~198MB without losing any functionality.