### PR TITLE
Fix FilterFunction delegate

### DIFF
--- a/lib/Utils.vala
+++ b/lib/Utils.vala
@@ -100,7 +100,7 @@ public class ValaLint.Utils : Object {
      * 
      * @return The filtered array.
      */
-    public delegate bool<G> FilterFunction<G> (G element);
+    public delegate bool FilterFunction<G> (G element);
     public static Vala.ArrayList<G> filter<G> (FilterFunction<G> func, Vala.ArrayList<G> source) {
         var result = new Vala.ArrayList<G> ();
 


### PR DESCRIPTION
There were compiler errors before making these changes:
```
../lib/Utils.vala:103.21-103.27: error: too many type arguments for `bool'
    public delegate bool<G> FilterFunction<G> (G element);
                    ^^^^^^^
```