### PR TITLE
Add new introspectable Vlint library

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -15,3 +15,18 @@ install_data(vala_linter_pc,
 	install_dir : join_paths(get_option('libdir'), 'pkgconfig')
 	)
 
+# Vlint library
+vconf = configuration_data()
+vconf.set('prefix', get_option ('prefix'))
+vconf.set('libdir', '${exec_prefix}/'+get_option ('libdir'))
+vconf.set('PROJECT_NAME', meson.project_name())
+vconf.set('VERSION', meson.project_version())
+vconf.set('LIBVALA', 'libvala-@0@ '.format(libvala_version)+libvala_required_version)
+vlint_pc = configure_file(input : 'vlint-1.pc.in',
+	output : 'vlint-1.pc',
+	configuration : vconf
+	)
+install_data(vlint_pc,
+	install_dir : join_paths(get_option('libdir'), 'pkgconfig')
+	)
+

--- a/data/vlint-1.pc.in
+++ b/data/vlint-1.pc.in
@@ -1,0 +1,13 @@
+prefix=@prefix@
+exec_prefix=${prefix}
+libdir=@libdir@
+datadir=${prefix}/share
+includedir=${prefix}/include
+
+Name: vlint-1
+Description: Library prividing a Vala code checker for format code-style errors
+URL: https://github.com/vala-lang/vala-lint
+Version: @VERSION@
+Requires: gio-2.0 >= 2.56.4 @LIBVALA@
+Libs: -L${libdir} -lvlint-1
+Cflags: -I${includedir}/vlint-1

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -67,3 +67,69 @@ vala_linter_dep = declare_dependency(
     link_with : vala_linter_library,
     include_directories: include_directories('.')
 )
+
+vlint_files = files(
+    'vlint-linter.vala'
+)
+
+vlint_deps = [
+    gio_dep,
+    libvala_dep,
+]
+
+# LT_VERSION for ABI related changes
+# From: https://autotools.io/libtool/version.html
+# This rules applies to Meson 0.43
+# Increase the current value whenever an interface has been added, removed or changed.
+# Always increase revision value whenever an interface has been added, removed or changed.
+# Increase the age value only if the changes made to the ABI are backward compatible.
+# Set version to the value of subtract age from current
+# Reset current and version to 1 and, age and version to 0 if library's name is changed
+LT_CURRENT='1'
+LT_REVISION='0'
+LT_AGE='0'
+LT_VERSION='1'
+vlint_library = shared_library(
+    'vlint-1',
+    vlint_files,
+    version : LT_VERSION,
+	soversion : LT_VERSION+'.'+LT_AGE+'.'+LT_REVISION,
+	vala_header : 'vlint.h',
+	vala_vapi : 'vlint-1.vapi',
+	vala_gir : 'Vlint-1.gir',
+    dependencies : vlint_deps,
+    link_with: [vala_linter_library],
+    install : true,
+	install_dir : [
+		get_option('libdir'),
+		join_paths (get_option('includedir'),'vlint-1'),
+		vapidir,
+		get_option('introspection')
+	]
+)
+
+vlint_source_dir = meson.current_source_dir ()
+vlint_build_dir = meson.current_build_dir ()
+vlint_dep = declare_dependency(
+    dependencies: vlint_deps,
+    link_with : vlint_library,
+    include_directories: include_directories('.')
+)
+
+if get_option('introspection')
+if g_ir_compiler.found()
+command = [
+	g_ir_compiler,
+	'--shared-library', 'lib@0@-@1@.so'.format ('vlint', 1),
+	'--includedir', vlint_build_dir,
+	'--output', '@OUTPUT@'
+]
+command += [ join_paths(meson.current_build_dir(), 'Vlint-1.gir') ]
+custom_target('typelib-vlint',
+	command: command,
+	output: 'Vlint-1.typelib',
+	depends: [vala_linter_library, vlint_library],
+	install: true,
+	install_dir: join_paths(get_option('libdir'), 'girepository-1.0'))
+endif
+endif

--- a/lib/vlint-linter.vala
+++ b/lib/vlint-linter.vala
@@ -1,0 +1,91 @@
+/* vlint-linter.vala
+ *
+ * Copyright 2019 Daniel Espinosa <esodan@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+ public class Vlint.Linter : GLib.Object {
+     private GLib.ListStore _mistakes;
+     public GLib.ListModel mistakes { get { return _mistakes; } }
+
+     construct {
+         _mistakes = new GLib.ListStore (typeof (Vlint.Mistake));
+     }
+
+     public void
+     check_file (GLib.File file) throws GLib.Error
+     {
+        _mistakes = new GLib.ListStore (typeof (Vlint.Mistake));
+        var l = new ValaLint.Linter ();
+        l.disable_mistakes = false;
+        var m = l.run_checks_for_file (file);
+        foreach (ValaLint.FormatMistake fm in m) {
+                Vlint.Mistake mt = new Vlint.Mistake ();
+                mt.message = fm.mistake;
+                Vlint.Position start = new Vlint.Position.from_values (fm.begin.line - 1, fm.begin.column - 1);
+                Vlint.Position end = new Vlint.Position.from_values (fm.end.line - 1, fm.end.column - 1);
+                mt.start = start;
+                mt.end = end;
+                _mistakes.append (mt);
+        }
+     }
+
+     public void
+     check_text (string content, string uri) throws GLib.Error
+     {
+        _mistakes = new GLib.ListStore (typeof (Vlint.Mistake));
+        var l = new ValaLint.Linter ();
+        l.disable_mistakes = false;
+        var m = l.run_checks_for_content (content, uri);
+        foreach (ValaLint.FormatMistake fm in m) {
+                Vlint.Mistake mt = new Vlint.Mistake ();
+                mt.message = fm.mistake;
+                Vlint.Position start = new Vlint.Position.from_values (fm.begin.line - 1, fm.begin.column - 1);
+                Vlint.Position end = new Vlint.Position.from_values (fm.end.line - 1, fm.end.column - 1);
+                mt.start = start;
+                mt.end = end;
+                _mistakes.append (mt);
+        }
+     }
+
+ }
+
+ public class Vlint.Mistake : GLib.Object {
+     public Vlint.Position start { get; set; }
+     public Vlint.Position end { get; set; }
+     public string uri { get; set; }
+     public string message { get; set; }
+
+     public Mistake.from_values (string uri,
+                                int start_line,
+                                int start_char,
+                                int end_line,
+                                int end_char)
+    {
+        start = new Vlint.Position.from_values (start_line, start_char);
+        end = new Vlint.Position.from_values (end_line, end_char);
+        this.uri = uri;
+    }
+ }
+
+ public class Vlint.Position : GLib.Object {
+     public int line { get; set; }
+     public int character { get; set; }
+
+     public Position.from_values (int line, int charater) {
+         this.line = line;
+         this.character = character;
+     }
+ }

--- a/meson.build
+++ b/meson.build
@@ -14,6 +14,8 @@ posix_dep = valac.find_library('posix')
 libvala_required_version = '>= 0.40.4'
 libvala_dep = dependency('libvala-@0@'.format(libvala_version), version: libvala_required_version)
 
+g_ir_compiler = find_program('g-ir-compiler', required: false)
+
 subdir('lib')
 subdir('src')
 subdir('test')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,1 @@
+option('introspection', type: 'boolean', value : 'true', description : 'Build GObject Introspection bindings genereation')


### PR DESCRIPTION
This new library is introspectable, so
it produce GIR/TYPELIB files to be used
by JavaScript, Python and any other library
introspectable depending on it.

These changes also fix memory leaks because
when running checks for files it never
removes created Vala.Context using pop()
method.