### PR TITLE
Print summary at the end of output

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -135,11 +135,11 @@ public class ValaLint.Application : GLib.Application {
         /* 4. Print mistakes */
         bool has_errors = print_mistakes (file_data_list);
 
-        if (exit_with_zero) {
+        if (exit_with_zero || !has_errors) {
             return 0;
+        } else {
+            return 1;
         }
-
-        return (int) has_errors;
     }
 
     Vala.ArrayList<FileData?> get_files (ApplicationCommandLine command_line, string[] patterns) throws Error, IOError {

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -243,15 +243,12 @@ public class ValaLint.Application : GLib.Application {
             }
         }
 
-        int total_mistakes = num_errors + num_warnings;
-        if (total_mistakes == 0) {
-            application_command_line.print (_("No mistakes found") + "\n");
+        if (num_errors + num_warnings == 0) {
+            application_command_line.print ("\033[1;32m" + _("No mistakes found") + "\033[0m\n");
             return false;
         }
 
-        string summary = ("\n" + _("%d %s (%d %s, %d %s)") + "\n").printf (
-            total_mistakes,
-            total_mistakes == 1 ? _("mistake") : _("mistakes"),
+        string summary = ("\n" + _("%d %s, %d %s") + "\n").printf (
             num_errors,
             num_errors == 1 ? _("error") : _("errors"),
             num_warnings,

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -19,7 +19,7 @@
  * Authored by: Marcus Wichelmann <marcus.wichelmann@hotmail.de>
  */
 
- public class ValaLint.Application : GLib.Application {
+public class ValaLint.Application : GLib.Application {
     private const string VERSION = "0.1";
 
     private static string? lint_directory = null;

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -259,6 +259,7 @@ public class ValaLint.Application : GLib.Application {
         } else {
             application_command_line.print (apply_color_for_state (summary, Config.State.WARN));
         }
+
         return num_errors > 0;
     }
 

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -19,7 +19,7 @@
  * Authored by: Marcus Wichelmann <marcus.wichelmann@hotmail.de>
  */
 
-public class ValaLint.Application : GLib.Application {
+ public class ValaLint.Application : GLib.Application {
     private const string VERSION = "0.1";
 
     private static string? lint_directory = null;
@@ -133,20 +133,13 @@ public class ValaLint.Application : GLib.Application {
         }
 
         /* 4. Print mistakes */
-        print_mistakes (file_data_list);
+        bool has_errors = print_mistakes (file_data_list);
 
         if (exit_with_zero) {
             return 0;
         }
 
-        foreach (FileData file_data in file_data_list) {
-            foreach (FormatMistake? mistake in file_data.mistakes) {
-                if (mistake.check.state == Config.State.ERROR) {
-                    return 1;
-                }
-            }
-        }
-        return 0;
+        return (int) has_errors;
     }
 
     Vala.ArrayList<FileData?> get_files (ApplicationCommandLine command_line, string[] patterns) throws Error, IOError {
@@ -207,30 +200,35 @@ public class ValaLint.Application : GLib.Application {
         return files;
     }
 
-    void print_mistakes (Vala.ArrayList<FileData?> file_data_list) {
+    bool print_mistakes (Vala.ArrayList<FileData?> file_data_list) {
+        int num_errors = 0;
+        int num_warnings = 0;
+
         foreach (FileData file_data in file_data_list) {
             if (!file_data.mistakes.is_empty) {
                 application_command_line.print ("\x001b[1m\x001b[4m" + "%s" + "\x001b[0m\n", file_data.name);
 
                 foreach (FormatMistake mistake in file_data.mistakes) {
+                    switch (mistake.check.state) {
+                        case ERROR:
+                            num_errors++;
+                            break;
+
+                        case WARN:
+                            num_warnings++;
+                            break;
+
+                        default:
+                            break;
+                    }
+
                     string color_state = "%-5s";
                     string mistakes_end = "";
                     if (print_mistakes_end) {
                         mistakes_end = "-%5i.%-3i".printf (mistake.end.line, mistake.end.column);
                     }
 
-                    switch (mistake.check.state) {
-                        case ERROR:
-                            color_state = "\033[1;31m" + color_state + "\033[0m"; // red
-                            break;
-
-                        case WARN:
-                            color_state = "\033[1;33m" + color_state + "\033[0m";  // yellow
-                            break;
-
-                        default:
-                            break;
-                    }
+                    color_state = apply_color_for_state (color_state, mistake.check.state);
 
                     application_command_line.print (
                         "\x001b[0m%5i.%-3i %s  " + color_state + "   %-45s   \033[2m%s\033[0m\n",
@@ -243,6 +241,40 @@ public class ValaLint.Application : GLib.Application {
                     );
                 }
             }
+        }
+
+        int total_mistakes = num_errors + num_warnings;
+        if (total_mistakes == 0) {
+            application_command_line.print (_("No mistakes found") + "\n");
+            return false;
+        }
+
+        string summary = ("\n" + _("%d %s (%d %s, %d %s)") + "\n").printf (
+            total_mistakes,
+            total_mistakes == 1 ? _("mistake") : _("mistakes"),
+            num_errors,
+            num_errors == 1 ? _("error") : _("errors"),
+            num_warnings,
+            num_warnings == 1 ? _("warning") : _("warnings")
+        );
+        if (num_errors > 0) {
+            application_command_line.print (apply_color_for_state (summary, Config.State.ERROR));
+        } else {
+            application_command_line.print (apply_color_for_state (summary, Config.State.WARN));
+        }
+        return num_errors > 0;
+    }
+
+    string apply_color_for_state (string str, Config.State state) {
+        switch (state) {
+            case ERROR:
+                return "\033[1;31m" + str + "\033[0m"; // red
+
+            case WARN:
+                return "\033[1;33m" + str + "\033[0m"; // yellow
+
+            default:
+                return str;
         }
     }
 


### PR DESCRIPTION
Prints a brief summary at the end of the output showing the total number of mistakes, number of warnings, and number of errors.

Output is colored based on the most severe mistake:
- No mistakes = no color applied
- Only warnings = yellow color applied
- Any errors = red color applied

<img width="711" alt="Screen Shot 2022-06-23 at 9 07 39 PM" src="https://user-images.githubusercontent.com/3663899/175454292-43138cff-d448-4a8f-995f-025149682634.png">

Resolves #136 
