### PR TITLE
Adds JSON output mode

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -13,6 +13,7 @@ gio_dep = dependency('gio-2.0', version: '>=2.56.4')
 posix_dep = valac.find_library('posix')
 libvala_required_version = '>= 0.40.4'
 libvala_dep = dependency('libvala-@0@'.format(libvala_version), version: libvala_required_version)
+json_dep = dependency('json-glib-1.0')
 
 subdir('lib')
 subdir('src')

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -424,8 +424,7 @@ public class ValaLint.Application : GLib.Application {
         Json.Generator generator = new Json.Generator ();
         Json.Node root = builder.get_root ();
         generator.set_root (root);
-        application_command_line.print (generator.to_data (null));
-        application_command_line.print ("\n");
+        application_command_line.print ("%s\n", generator.to_data (null));
 
         if (num_errors + num_warnings == 0) {
             return false;

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -383,7 +383,7 @@ public class ValaLint.Application : GLib.Application {
                     if (first_mistake) {
                         first_mistake = false;
                     } else {
-                        application_command_line.print(",");
+                        application_command_line.print (",");
                     }
                     switch (mistake.check.state) {
                         case ERROR:
@@ -404,7 +404,12 @@ public class ValaLint.Application : GLib.Application {
                     }
 
                     application_command_line.print (
-                        "{\"filename\":\"%s\",\"line\":%i,\"column\":%i,%s\"level\":\"%s\",\"message\":\"%s\",\"ruleId\":\"%s\"}",
+                        "{\"filename\":\"%s\"," +
+                        "\"line\":%i," +
+                        "\"column\":%i,%s" +
+                        "\"level\":\"%s\"," +
+                        "\"message\":\"%s\"," +
+                        "\"ruleId\":\"%s\"}",
                         file_data.name,
                         mistake.begin.line,
                         mistake.begin.column,

--- a/src/meson.build
+++ b/src/meson.build
@@ -8,7 +8,8 @@ vala_lint = executable(
     app_files,
     dependencies: [
         vala_linter_dep,
-        posix_dep
+        posix_dep,
+        json_dep
     ],
     install : true
 )


### PR DESCRIPTION
Resolves issue #169 

Feedback on the exact format this outputs is welcome. As far as code style goes, this has a bit of duplication but outside of a fairly large overhaul to the string generation this feels like the cleanest way to accomplish this.

Sample  with -p (added by this PR) and -e flags specified
![image](https://github.com/vala-lang/vala-lint/assets/21345721/7d4b9a59-165e-4323-b253-3be652fbb1be)

Keep in mind this is meant to be easier for regex/pattern matching to parse, and is not meant to be human readable.