### PR TITLE
Fix error when providing only flags and no path

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -105,6 +105,10 @@ public class ValaLint.Application : GLib.Application {
         /* Get ignore patterns. Ignore patterns are glob patterns relative to the scanned directory */
         string[] ignore_patterns = {};
         string ignore_root = lint_directory != null ? lint_directory : args[1];
+        if (ignore_root == null) {
+            ignore_root = tmp[1] = ".";
+            tmp.length += 1;
+        }
         if (ignore_root.has_suffix (Path.DIR_SEPARATOR_S)) {
             ignore_root = ignore_root[0 : -1];
         }


### PR DESCRIPTION
If you were to provide only options and no paths, you would get a Critical log from GLib's `has_suffix`, and the `file_name_list` would end up being empty, rather than using the current directory. This is because `option_context.parse` actually removes the arguments from the args array when it parses them. So when only command line flags are provided, `args[1]` ends up being null on `Application.vala` line 108 (112 in the PR).

The fix in this PR is to put `"."` as both `ignore_root` and `tmp[1]` (which is pointing to the same memory as `args` and is used later for the `file_name_list`). Alternative solutions would be:

1. Setting `lint_directory = "."` in the same situation. I avoided doing this since that variable is linked to a deprecated flag.
2.  Not using `tmp` at all and moving the code replacing args with `{ args[0], "." }` to after `option_context.parse`.