### PR TITLE
Docker: Use recommends from packages at build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN mkdir -p /opt/vala-lint-portable
 COPY . /opt/vala-lint
 
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends gcc libjson-glib-dev libvala-dev valac meson\
+  && apt-get install -y gcc libjson-glib-dev libvala-dev valac meson\
   && cd /opt/vala-lint \
   && meson build --prefix=/usr \
   && cd build \


### PR DESCRIPTION
We especially need dpkg-dev from the meson recommends to be able to use the right library directory automatically.

Closes: https://github.com/vala-lang/vala-lint/issues/175