### PR TITLE
Add support for pre-commit

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+- id: vala-lint
+  name: Vala-Lint
+  language: docker_image
+  entry: --entrypoint /usr/bin/io.elementary.vala-lint valalang/lint:latest --fix
+  description: Check Vala code files for code-style errors.
+  files: \.vala$

--- a/README.md
+++ b/README.md
@@ -155,3 +155,13 @@ You may also ignore specific kinds of `.vala` files like
 Vala-Lint is primarily intended to be used in Continuous Integration (CI). It's available in a convenient, always up-to-date Docker container `valalang/lint:latest` hosted on Docker Hub.
 
     docker run -v "$PWD":/app valalang/lint:latest
+
+### pre-commit Integration
+You can use Vala-Lint via [pre-commit](https://pre-commit.com/) by adding the following entry to your `.pre-commit-config.yaml`:
+
+```yaml
+- repo: https://github.com/vala-lang/vala-lint
+  rev: master
+  hooks:
+  - id: vala-lint
+```


### PR DESCRIPTION
Users can use Vala-Lint via [pre-commit](https://pre-commit.com/) by adding the following entry to their `.pre-commit-config.yaml`:

```yaml
- repo: https://github.com/vala-lang/vala-lint
  rev: master
  hooks:
  - id: vala-lint
```