### PR TITLE
Fix issue #181 plus a few meson warnings

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,13 +1,13 @@
 project(
     'io.elementary.vala-lint', 'vala', 'c',
     version: '0.1.0',
-    meson_version : '>= 0.43'
+    meson_version : '>= 0.56'
 )
 
 add_project_arguments('-DGETTEXT_PACKAGE="@0@"'.format(meson.project_name()), language:'c')
 
 valac = meson.get_compiler('vala')
-libvala_version = run_command(valac.cmd_array()[0], '--api-version').stdout().strip()
+libvala_version = run_command(valac.cmd_array()[0], '--api-version', check: true).stdout().strip()
 
 gio_dep = dependency('gio-2.0', version: '>=2.56.4')
 posix_dep = valac.find_library('posix')

--- a/test/AutoFixTest.vala
+++ b/test/AutoFixTest.vala
@@ -39,9 +39,9 @@ class AutoFixTest : GLib.Object {
         if (src_type == DIRECTORY) {
             if (!dest.query_exists ()) {
                 dest.make_directory (cancellable);
+                src.copy_attributes (dest, flags, cancellable);
             }
 
-            src.copy_attributes (dest, flags, cancellable);
 
             string src_path = src.get_path ();
             string dest_path = dest.get_path ();

--- a/test/meson.build
+++ b/test/meson.build
@@ -41,4 +41,4 @@ test_envars = [
 test('file', file_test, env: test_envars)
 test('auto-fix', auto_fix_test, env: test_envars)
 
-test('self', vala_lint, workdir: meson.source_root(), env: test_envars)
+test('self', vala_lint, workdir: meson.current_source_dir(), env: test_envars)


### PR DESCRIPTION
1. Moving one line in AutoFixTest.vala fixes test crashing.
2. Bumped meson version to >= 0.56
3. Changes in meson.build to avoid warnings.