### PR TITLE
build: Disable C warnings

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -15,6 +15,11 @@ libvala_required_version = '>= 0.40.4'
 libvala_dep = dependency('libvala-@0@'.format(libvala_version), version: libvala_required_version)
 json_dep = dependency('json-glib-1.0')
 
+add_project_arguments(
+    '-w',
+    language: 'C'
+)
+
 subdir('lib')
 subdir('src')
 subdir('test')


### PR DESCRIPTION
According to 'recommended approach' at vala documentation https://docs.vala.dev/tutorials/programming-language/main/07-00-tools/07-01-valac.html